### PR TITLE
Small edit to save generated files inside module into generated folder...

### DIFF
--- a/modules/dsb/dsb_ide_helper/controllers/admin/dsb_ide_helper.php
+++ b/modules/dsb/dsb_ide_helper/controllers/admin/dsb_ide_helper.php
@@ -96,9 +96,10 @@ class dsb_ide_helper extends oxAdminView
          * @var oxModule $oModule
          */
         $oModuleList           = oxNew('oxmodulelist');
+        $oViewConfig           = oxNew('oxviewconfig');
         $aModules              = $oModuleList->getModules();
         $aDisabledModules      = $oModuleList->getDisabledModules();
-        $moduleBasePath        = $this->getConfig()->getModulesDir(true);
+        $moduleBasePath        = $oViewConfig->getModulePath('dsb_ide_helper');
         $this->_aModuleClasses = array();
         foreach ($aModules as $sClassName => $sModuleClasses) {
         	$aModuleClasses = explode('&', $sModuleClasses);
@@ -112,7 +113,7 @@ class dsb_ide_helper extends oxAdminView
                 $aDirectories     = explode(DIRECTORY_SEPARATOR, $sModuleClass);
                 $sModuleClassName = $aDirectories[count($aDirectories) - 1] . '_parent';
                 unset($aDirectories[count($aDirectories) - 1]);
-                $sFilePath               = $moduleBasePath . implode(DIRECTORY_SEPARATOR, $aDirectories) . DIRECTORY_SEPARATOR;
+                $sFilePath               = $moduleBasePath . DIRECTORY_SEPARATOR . 'generated' . DIRECTORY_SEPARATOR;
                 $this->_aModuleClasses[] = array(
                     'fileName' => $sFilePath . $sModuleClassName . '.php',
                     'content'  => $this->getFileContent($sModuleClassName, $sParentClassName),


### PR DESCRIPTION
...not to make mess around with generated files.

This is useful because sometimes you need to add all module folder to GIT and commit it all, but you shouldn't make _parent files there, so it's better to save generated _parent files to folder inside module directory. Also it's easier to delete generated files after removing module for some reason. 

I have tested my changes on EE 5.1.3 and everything works as it should.
